### PR TITLE
docs: replace unsupported `git` url with `https`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ ./wasm3 coremark.wasm
 Before building, please get familiar with [OpenWrt build system](https://openwrt.org/docs/guide-developer/build-system/start) and how to [build OpenWrt packages](https://openwrt.org/docs/guide-developer/build.a.package).
 
 ```bash
-echo "src-git wasm3 git://github.com/wasm3/wasm3-openwrt-packages.git" >> ./feeds.conf
+echo "src-git wasm3 https://github.com/wasm3/wasm3-openwrt-packages.git" >> ./feeds.conf
 ./scripts/feeds update -a
 ./scripts/feeds install -p wasm3 -a
 make menuconfig


### PR DESCRIPTION
GitHub has removed support for the insecure `git://` Git protocol, as of March 15th 2022, see https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

> If you’re having trouble [cloning a repository](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories), make sure the URL starts with `ssh://`, `https://`, or `git@github.com`.