### PR TITLE
wasm3: fix incorrect download URL

### DIFF
--- a/wasm3/wasm3/Makefile
+++ b/wasm3/wasm3/Makefile
@@ -9,9 +9,8 @@ PKG_LICENSE:=MIT
 
 #PKG_SOURCE_URL:=file:///path/to/local/wasm3/
 
-PKG_SOURCE_URL:=https://github.com/wasm3/wasm3/archive/main.tar.gz
-#PKG_SOURCE_URL:=https://github.com/wasm3/wasm3/archive/v$(PKG_VERSION).tar.gz
-#PKG_HASH:=b778dd72ee2251f4fe9e2666ee3fe1c26f06f517c3ffce572416db067546536c
+PKG_SOURCE_URL:=https://github.com/wasm3/wasm3/archive/v$(PKG_VERSION)/
+PKG_HASH:=b778dd72ee2251f4fe9e2666ee3fe1c26f06f517c3ffce572416db067546536c
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 


### PR DESCRIPTION
`PKG_SOURCE_URL` must not point to the `.tar.gz` file, instead it must point to the directory of the download, while `PKG_SOURCE` points to the `.tar.gz`

See the [**Creating packages** guide on the OpenWRT Wiki][1].

As an example, see the [websocketpp Makefile][2].

[1]: https://openwrt.org/docs/guide-developer/packages#buildpackage_variables
[2]: https://github.com/openwrt/packages/blob/f08eb8552c6bd71124a5407fb37abe6dc4982ac3/libs/websocketpp/Makefile#L11-L13

For `PKG_VERSION:=0.5.0`, release, the URL will be <https://github.com/wasm3/wasm3/archive/v0.5.0/wasm3-0.5.0.tar.gz>